### PR TITLE
IOT-11 Created wrapper for queue

### DIFF
--- a/Core/Src/HAL/RTOSWrappers/QueueWrapper.cpp
+++ b/Core/Src/HAL/RTOSWrappers/QueueWrapper.cpp
@@ -4,5 +4,53 @@
  *  Created on: Mar 23, 2024
  *      Author: BrunoOtavio
  */
+#include "QueueWrapper.h"
 
+namespace HAL {
+namespace RtosWrappers {
 
+QueueWrapper::QueueWrapper() {
+
+}
+
+QueueWrapper::~QueueWrapper() {
+
+}
+
+GenericQueueHandle QueueWrapper::CreateQueue(int size, int item_size) {
+    #ifdef FREERTOS
+		return xQueueCreate(size, item_size);
+    #endif
+		return nullptr;
+}
+
+int QueueWrapper::QueueSpacesAvailable(GenericQueueHandle queue) {
+#ifdef FREERTOS
+	return uxQueueSpacesAvailable(queue);
+#endif
+	return 0;
+}
+
+void QueueWrapper::QueueDelete(GenericQueueHandle queue) {
+#ifdef FREERTOS
+	vQueueDelete(queue);
+#endif
+	return;
+}
+
+bool QueueWrapper::QueueSend(GenericQueueHandle queue, const void *item, int ms_to_wait) {
+#ifdef FREERTOS
+	return (xQueueSend(queue, item, pdMS_TO_TICKS(ms_to_wait)) == pdTRUE);
+#endif
+	return false;
+}
+
+bool QueueWrapper::QueueReceive(GenericQueueHandle queue, void *buffer, int ms_to_wait) {
+#ifdef FREERTOS
+	return (xQueueReceive(queue, buffer, pdMS_TO_TICKS(ms_to_wait)) == pdTRUE);
+#endif
+	return false;
+}
+
+}
+}

--- a/Core/Src/HAL/RTOSWrappers/QueueWrapper.h
+++ b/Core/Src/HAL/RTOSWrappers/QueueWrapper.h
@@ -8,10 +8,31 @@
 #ifndef SRC_HAL_RTOSWRAPPERS_QUEUEWRAPPER_H_
 #define SRC_HAL_RTOSWRAPPERS_QUEUEWRAPPER_H_
 
+#include <memory>
+
 #ifdef FREERTOS
+#include "FreeRTOS.h"
 #include "queue.h"
+typedef QueueHandle_t GenericQueueHandle;
+#else
+typedef int* GenericQueueHandle;
 #endif
 
+namespace HAL {
+namespace RtosWrappers {
+class QueueWrapper
+{
+public:
+    QueueWrapper();
+    ~QueueWrapper();
+    GenericQueueHandle CreateQueue(int size, int item_size);
+    int QueueSpacesAvailable(GenericQueueHandle queue);
+    void QueueDelete(GenericQueueHandle queue);
+    bool QueueSend(GenericQueueHandle queue, const void *item, int ms_to_wait);
+    bool QueueReceive(GenericQueueHandle queue, void *buffer, int ms_to_wait);
+};
 
+}
+}
 
 #endif /* SRC_HAL_RTOSWRAPPERS_QUEUEWRAPPER_H_ */

--- a/Core/Src/HAL/RTOSWrappers/RtosUtilsWrapper.h
+++ b/Core/Src/HAL/RTOSWrappers/RtosUtilsWrapper.h
@@ -1,0 +1,35 @@
+/*
+ * RtosUtilsWrapper.h
+ *
+ *  Created on: 24 de mar de 2024
+ *      Author: BrunoOtavio
+ */
+
+#ifndef SRC_HAL_RTOSWRAPPERS_RTOSUTILSWRAPPER_H_
+#define SRC_HAL_RTOSWRAPPERS_RTOSUTILSWRAPPER_H_
+
+#include <memory>
+
+#include "QueueWrapper.h"
+#include "SemaphoreWrapper.h"
+
+namespace HAL {
+namespace RtosWrappers {
+
+class RtosUtilsWrapper
+{
+public:
+    RtosUtilsWrapper() {
+
+    }
+
+    ~RtosUtilsWrapper() {
+
+    }
+
+    std::shared_ptr<QueueWrapper> queue_manager_;
+};
+}
+}
+
+#endif /* SRC_HAL_RTOSWRAPPERS_RTOSUTILSWRAPPER_H_ */

--- a/Core/Src/HAL/RTOSWrappers/TaskWrapper.h
+++ b/Core/Src/HAL/RTOSWrappers/TaskWrapper.h
@@ -5,7 +5,7 @@
 #include "FreeRTOS.h"
 #include "task.h"
 typedef TaskHandle_t GenericTaskHandle;
-#elif
+#else
 typedef int GenericTaskHandle;
 #endif
 


### PR DESCRIPTION
- It was created a RtosUtils class that will group all these functionalities, any object that need any of these would get it throught constructor and access everything throught a single object, in this way, we prevent the constructor to get a lot of objects in the future, just by adding at the utils object.